### PR TITLE
Edited default arguments for ip and port in operate.py

### DIFF
--- a/Week00-01/README.md
+++ b/Week00-01/README.md
@@ -25,7 +25,10 @@ You will implement keyboard teleoperations by editing [line 142 - 155 of operate
 
 **You don't have to use the provided scripts.** Feel free to be creative and write your own scripts for teleoperating the robot with keyboard.
 
-If you don't want to type the ```--ip``` and ```--port``` args every time, simply change the default arg values ([line 176-177 in operate.py](operate.py#L176)) to the robot's ip ```192.168.50.1``` and port ```8080```, then the next time you run operate.py with the physical robot you won't need to specify the ip and port any more, simply run ```python3 operate.py```.
+~If you don't want to type the ```--ip``` and ```--port``` args every time, simply change the default arg values ([line 176-177 in operate.py](operate.py#L176)) to the robot's ip ```192.168.50.1``` and port ```8080```, then the next time you run operate.py with the physical robot you won't need to specify the ip and port any more, simply run ```python3 operate.py```.~
+**The updated operate.py should enable you to run the physical robot just by running ```python3 operate.py````. If you installed the simulation environment and want to run operate.py in simulation, run python3 operate.py --ip localhost --port 40000**
+
+
 ---
 
 ## Marking Instructions 

--- a/Week00-01/operate.py
+++ b/Week00-01/operate.py
@@ -173,8 +173,8 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ip", metavar='', type=str, default='localhost')
-    parser.add_argument("--port", metavar='', type=int, default=40000)
+    parser.add_argument("--ip", metavar='', type=str, default='192.168.50.1')
+    parser.add_argument("--port", metavar='', type=int, default=8080)
     parser.add_argument("--save_data", action='store_true')
     parser.add_argument("--play_data", action='store_true')
     args, _ = parser.parse_known_args()


### PR DESCRIPTION
Students should be able to simply run:

python3 operate.py OR python operate.py

Shouldn't need to type --ip and --port.

This should work just fine. Some students tried this in Monday 1700 lab and seemed to work. If you want, test it before merging PR.